### PR TITLE
Improved title comparison and added unittests

### DIFF
--- a/argosd/settings_default.py
+++ b/argosd/settings_default.py
@@ -10,3 +10,6 @@ LOG_PATH = '/var/log/argosd'
 it will be downloaded regardless of how long it might wait
 for a better quality episode."""
 QUALITY_THRESHOLD = 1080
+
+# These settings are supposed to be overwritten in a settings_local file.
+RSS_FEED = None

--- a/argosd/tasks.py
+++ b/argosd/tasks.py
@@ -87,7 +87,7 @@ class RSSFeedParserTask(BaseTask):
         episodes = []
         for item in feed.entries:
             for show in shows:
-                if show.title in item.title:
+                if self._match_titles(show.title, item.title):
                     episode = self._get_episode_data_from_item(item, show)
                     episodes.append(episode)
 
@@ -95,6 +95,13 @@ class RSSFeedParserTask(BaseTask):
                     break
 
         return episodes
+
+    @staticmethod
+    def _match_titles(title_show, title_feed_item):
+        # Strip all except letters, numbers and spaces and convert to lowercase
+        title_show = re.sub('[^a-zA-Z0-9 ]', '', title_show).lower()
+        title_feed_item = re.sub('[^a-zA-Z0-9 ]', '', title_feed_item).lower()
+        return title_show in title_feed_item
 
     @staticmethod
     def _get_episode_data_from_item(item, show):

--- a/tests/argosd/test_tasks.py
+++ b/tests/argosd/test_tasks.py
@@ -1,14 +1,88 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from datetime import datetime, timedelta
 
 from peewee import SqliteDatabase
 from playhouse.test_utils import test_database
 
-from argosd.tasks import EpisodeDownloadTask
+from argosd.tasks import RSSFeedParserTask, EpisodeDownloadTask
 from argosd.models import Show, Episode
+from tests.dataproviders import rss
 
 database = SqliteDatabase('argosd_test.db')
+
+
+class RSSFeedParserTaskTestCase(unittest.TestCase):
+
+    def _get_new_dummy_show(self):
+        show = Show()
+        show.title = 'testshow'
+        show.follow_from_season = 1
+        show.follow_from_episode = 1
+        show.quality_threshold = 720
+        return show
+
+    @patch('argosd.settings.RSS_FEED', rss.SINGLE_MATCHING_ITEM)
+    def test_parse_single_episodes_from_feed(self):
+        with test_database(database, (Show, Episode)):
+            show = self._get_new_dummy_show()
+            show.save()
+
+            rssfeedparsertask = RSSFeedParserTask()
+            episodes = rssfeedparsertask._parse_episodes_from_feed()
+
+            self.assertEqual(len(episodes), 1)
+            self.assertEqual(episodes[0].title, 'testshow')
+
+    @patch('argosd.settings.RSS_FEED', rss.MULTIPLE_MATCHING_ITEMS)
+    def test_parse_multiple_full_episodes_from_feed(self):
+        with test_database(database, (Show, Episode)):
+            show = self._get_new_dummy_show()
+            show.save()
+
+            rssfeedparsertask = RSSFeedParserTask()
+            episodes = rssfeedparsertask._parse_episodes_from_feed()
+
+            self.assertEqual(len(episodes), 3)
+            self.assertEqual(episodes[0].title, 'testshow')
+            self.assertEqual(episodes[0].season, 2)
+            self.assertEqual(episodes[0].episode, 3)
+            self.assertEqual(episodes[0].quality, 720)
+
+            self.assertEqual(episodes[1].title, 'testshow')
+            self.assertEqual(episodes[1].season, 2)
+            self.assertEqual(episodes[1].episode, 3)
+            self.assertEqual(episodes[1].quality, 1080)
+
+            self.assertEqual(episodes[2].title, 'testshow')
+            self.assertEqual(episodes[2].season, 2)
+            self.assertEqual(episodes[2].episode, 3)
+            self.assertEqual(episodes[2].quality, 480)
+
+    @patch('argosd.settings.RSS_FEED', rss.SINGLE_ITEM_CAPITALISATION)
+    def test_parse_capitalised_episodes_from_feed(self):
+        with test_database(database, (Show, Episode)):
+            show = self._get_new_dummy_show()
+            show.save()
+
+            rssfeedparsertask = RSSFeedParserTask()
+            episodes = rssfeedparsertask._parse_episodes_from_feed()
+
+            self.assertEqual(len(episodes), 1)
+            self.assertEqual(episodes[0].title, 'testshow')
+
+    @patch('argosd.settings.RSS_FEED', rss.SINGLE_ITEM_SPECIAL_CHARS)
+    def test_parse_special_chars_episodes_from_feed(self):
+        with test_database(database, (Show, Episode)):
+            show = self._get_new_dummy_show()
+            show.title = 'Mr. Robot'
+            show.save()
+
+            rssfeedparsertask = RSSFeedParserTask()
+            episodes = rssfeedparsertask._parse_episodes_from_feed()
+
+            self.assertEqual(len(episodes), 1)
+            self.assertEqual(episodes[0].title, 'Mr. Robot')
 
 
 class EpisodeDownloadTaskTestCase(unittest.TestCase):

--- a/tests/dataproviders/rss.py
+++ b/tests/dataproviders/rss.py
@@ -1,0 +1,51 @@
+SINGLE_MATCHING_ITEM = """
+<rss version="2.0">
+    <channel>
+        <item>
+            <title>testshow</title>
+            <link>testlink</link>
+        </item>
+    </channel>
+</rss>
+"""
+
+SINGLE_ITEM_CAPITALISATION = """
+<rss version="2.0">
+    <channel>
+        <item>
+            <title>TestShow</title>
+            <link>testlink</link>
+        </item>
+    </channel>
+</rss>
+"""
+
+SINGLE_ITEM_SPECIAL_CHARS = """
+<rss version="2.0">
+    <channel>
+        <item>
+            <title>Mr Robot</title>
+            <link>testlink</link>
+        </item>
+    </channel>
+</rss>
+"""
+
+MULTIPLE_MATCHING_ITEMS = """
+<rss version="2.0">
+    <channel>
+        <item>
+            <title>testshow S02E03 720p</title>
+            <link>testlink</link>
+        </item>
+        <item>
+            <title>testshow S2E3 1080i</title>
+            <link>testlink</link>
+        </item>
+        <item>
+            <title>testshow 02x03 480p</title>
+            <link>testlink</link>
+        </item>
+    </channel>
+</rss>
+"""


### PR DESCRIPTION
There was a bug in title comparison. It was done case-sensitive and "Mr. Robot" and "Mr Robot" were not a match. The last is more a feature than a bug, but fixed anyway. Unittests have been added to ensure this keeps working.