### PR TITLE
Catch torrents already added to torrentclient

### DIFF
--- a/argosd/models.py
+++ b/argosd/models.py
@@ -34,6 +34,10 @@ class Episode(BaseModel):
     is_downloaded = BooleanField(default=False)
     created_at = TimestampField()
 
+    def __unicode__(self):
+        return '{} - S{} - E{} - Q{}'.format(
+            self.show.title, self.season, self.episode, self.quality)
+
     class Meta:
         indexes = (
             # Unique key on show/season/episode/quality

--- a/argosd/torrentclient.py
+++ b/argosd/torrentclient.py
@@ -10,6 +10,12 @@ class TorrentClientException(Exception):
     pass
 
 
+class TorrentAlreadyDownloadedException(Exception):
+    """Exception raised when a torrent is added to a torrentclient,
+    but the torrentclient already has downloaded it."""
+    pass
+
+
 class TorrentClient(metaclass=ABCMeta):
     """Abastract class for a torrentclient."""
 
@@ -18,6 +24,13 @@ class TorrentClient(metaclass=ABCMeta):
         """Add a torrent file from a URL to the client."""
         raise NotImplementedError
 
+    @staticmethod
+    def raise_exception(message):
+        """Shorthand to raise a TorrentClientException.
+        All exceptions should be converted to this type
+        so they can be handled outside of this scope."""
+        raise TorrentClientException(message)
+
 
 class Transmission(TorrentClient):
     """Connects with a Transmission server."""
@@ -25,16 +38,25 @@ class Transmission(TorrentClient):
     _client = None
 
     def __init__(self):
-        self._client = transmissionrpc.Client(
-            address=settings.TRANSMISSION_HOST,
-            port=settings.TRANSMISSION_PORT,
-            user=settings.TRANSMISSION_USERNAME,
-            password=settings.TRANSMISSION_PASSWORD)
+        try:
+            self._client = transmissionrpc.Client(
+                address=settings.TRANSMISSION_HOST,
+                port=settings.TRANSMISSION_PORT,
+                user=settings.TRANSMISSION_USERNAME,
+                password=settings.TRANSMISSION_PASSWORD)
+        except transmissionrpc.TransmissionError as e:
+            self.raise_exception(str(e))
 
     def download_torrent(self, torrent_link):
         """Add a torrent file from a URL to the client."""
-        torrent = self._client.add_torrent(torrent_link)
-        if not torrent:
-            message = 'Could not add torrent "{}" to Transmission' \
-                .format(torrent_link)
-            raise TorrentClientException(message)
+        try:
+            torrent = self._client.add_torrent(torrent_link)
+            if not torrent:
+                message = 'Could not add torrent "{}" to Transmission' \
+                    .format(torrent_link)
+                raise TorrentClientException(message)
+        except transmissionrpc.TransmissionError as e:
+            if e.message == 'Query failed with result "duplicate torrent".':
+                raise TorrentAlreadyDownloadedException()
+
+            self.raise_exception(str(e))

--- a/tests/dataproviders/test_torrentclient.py
+++ b/tests/dataproviders/test_torrentclient.py
@@ -1,0 +1,14 @@
+import unittest
+from unittest.mock import patch
+
+from argosd.torrentclient import TorrentAlreadyDownloadedException
+from tests.dataproviders.torrentclient import TransmissionAlreadyDownloaded
+
+
+class TransmissionAlreadyDownloadedTestCase(unittest.TestCase):
+
+    @patch('argosd.tasks.Transmission',
+           new_callable=TransmissionAlreadyDownloaded)
+    def test_download_torrent_raises_exception(self, torrent):
+        with self.assertRaises(TorrentAlreadyDownloadedException):
+            torrent.download_torrent('test')

--- a/tests/dataproviders/torrentclient.py
+++ b/tests/dataproviders/torrentclient.py
@@ -1,0 +1,10 @@
+from unittest.mock import MagicMock
+
+from argosd.torrentclient import TorrentClient, \
+    TorrentAlreadyDownloadedException
+
+
+class TransmissionAlreadyDownloaded(MagicMock):
+
+    def download_torrent(self, link):
+        raise TorrentAlreadyDownloadedException()


### PR DESCRIPTION
This fixes the issue raised in #20. Torrents that are already added to the torrentclient are now being updated with "is_downloaded" set to True, because they are already downloaded. This prevents a situation wherein a manually added torrent is being automatically downloaded as well.