### PR TITLE
Spawn API process without inheriting resources

### DIFF
--- a/argosd/api/app.py
+++ b/argosd/api/app.py
@@ -12,19 +12,9 @@ from argosd.api.resources.episodes import EpisodesResource
 class Api:
     """Creates a RESTful API."""
 
-    _app = None
-    _api = None
     _process = None
 
     def __init__(self):
-        self._app = Flask('argosd')
-
-        self._api = flask_restful.Api(self._app)
-
-        self._api.add_resource(ShowsResource, '/shows')
-        self._api.add_resource(ShowResource, '/shows/<int:show_id>')
-        self._api.add_resource(EpisodesResource, '/episodes')
-
         self._process = Process(name='Api', target=self.deferred)
 
     def run(self):
@@ -43,8 +33,12 @@ class Api:
     def deferred(self):
         """Runs the API, listens to external requests."""
         # Remove all log handlers set in the main process
-        for handler in logging.root.handlers[:]:
-            logging.root.removeHandler(handler)
+        app = Flask('argosd')
+        api = flask_restful.Api(app)
+
+        api.add_resource(ShowsResource, '/shows')
+        api.add_resource(ShowResource, '/shows/<int:show_id>')
+        api.add_resource(EpisodesResource, '/episodes')
 
         logfile = '{}/api.log'.format(settings.LOG_PATH)
         logformat = '%(message)s'
@@ -52,4 +46,4 @@ class Api:
         logging.basicConfig(format=logformat, level=logging.INFO,
                             filename=logfile, filemode='a')
 
-        self._app.run(host='0.0.0.0', port=27467)
+        app.run(host='0.0.0.0', port=27467)

--- a/main.py
+++ b/main.py
@@ -1,19 +1,24 @@
 import logging
+import multiprocessing
 
 from argosd import argosd, settings
 
 
-logformat = '[%(asctime)s] [%(thread)d] [%(levelname)s] %(message)s'
-loglevel = logging.DEBUG if settings.DEBUG else logging.INFO
-logfile = '{}/argosd.log'.format(settings.LOG_PATH)
+if __name__ == '__main__':
+    # Spawn fresh processes, without inheriting resources
+    multiprocessing.set_start_method('spawn')
 
-logging.basicConfig(format=logformat, level=loglevel,
-                    filename=logfile, filemode='a')
+    logformat = '[%(asctime)s] [%(thread)d] [%(levelname)s] %(message)s'
+    loglevel = logging.DEBUG if settings.DEBUG else logging.INFO
+    logfile = '{}/argosd.log'.format(settings.LOG_PATH)
 
-# Don't let schedule's logger write to our logfile,
-# schedule logs an info-event for each action.
-logger = logging.getLogger('schedule')
-logger.propagate = False
+    logging.basicConfig(format=logformat, level=loglevel,
+                        filename=logfile, filemode='a')
 
-argosd = argosd.ArgosD()
-argosd.run()
+    # Don't let schedule's logger write to our logfile,
+    # schedule logs an info-event for each action.
+    logger = logging.getLogger('schedule')
+    logger.propagate = False
+
+    argosd = argosd.ArgosD()
+    argosd.run()


### PR DESCRIPTION
This fixes an issue where `systemctl restart argosd` wouldn't start the API correctly.